### PR TITLE
remove security exclusions for the Bower mode

### DIFF
--- a/src/main/java/com/vaadin/tutorial/crm/security/SecurityConfiguration.java
+++ b/src/main/java/com/vaadin/tutorial/crm/security/SecurityConfiguration.java
@@ -69,7 +69,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Override
 	public void configure(WebSecurity web) {
 		web.ignoring().antMatchers(
-				// Vaadin static resources
+				// client-side JS code
 				"/VAADIN/**",
 
 				// the standard favicon URI
@@ -88,13 +88,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				"/images/**",
 				"/styles/**",
 
-				// (development mode) static resources
-				"/frontend/**",
-
 				// (development mode) H2 debugging console
-				"/h2-console/**",
-
-				// (production mode) static resources
-				"/frontend-es5/**", "/frontend-es6/**");
+				"/h2-console/**"
+		);
 	}
 }


### PR DESCRIPTION
The `/frontend/**`, `/frontend-es5/**` and `/frontend-es6/**` paths are no longer used in the npm mode. With npm and Webpack, the compiled frontend bundles end up in `/VAADIN/build/**`.